### PR TITLE
Keeping the initial mouse mode when switching back to the character camera

### DIFF
--- a/addons/runtime_debug_tools/scripts/debug_runtime_interaction_2d.gd
+++ b/addons/runtime_debug_tools/scripts/debug_runtime_interaction_2d.gd
@@ -9,9 +9,9 @@ signal on_object_picked(node)
 
 var _is_active = false
 var _previous_camera : Camera2D
-var _initialMouseMode : Input.MouseMode
+var _previous_mouse_mode : Input.MouseMode
 var _is_game_process_in_focus: bool
-var _set_initial_mouse_mode : bool
+var _restore_previous_mouse_mode : bool
 var _use_only_physics_for_picking = false
 
 var _picker_ignore_nodes := {}
@@ -43,14 +43,14 @@ func set_active(on):
         _debug_camera.enabled = true
         _debug_camera.make_current()
 
-        _initialMouseMode = Input.get_mouse_mode()
+        _previous_mouse_mode = Input.get_mouse_mode()
     else:
         if _previous_camera:
             _debug_camera.enabled = false
             _previous_camera.make_current()
             _previous_camera = null
 
-        _set_initial_mouse_mode = true
+        _restore_previous_mouse_mode = true
 
     _is_active = on
     _update_gizmo()
@@ -83,9 +83,10 @@ func _ready():
     _ignore_nodes(get_parent())
     
 func _process(_delta: float) -> void:
-    if _is_game_process_in_focus and _set_initial_mouse_mode:
-        Input.mouse_mode = _initialMouseMode
-        _set_initial_mouse_mode = false;
+    
+    if get_window().has_focus() and _restore_previous_mouse_mode:
+        Input.mouse_mode = _previous_mouse_mode
+        _restore_previous_mouse_mode = false;
 
     if not _is_active:
         return

--- a/addons/runtime_debug_tools/scripts/debug_runtime_interaction_2d.gd
+++ b/addons/runtime_debug_tools/scripts/debug_runtime_interaction_2d.gd
@@ -10,7 +10,6 @@ signal on_object_picked(node)
 var _is_active = false
 var _previous_camera : Camera2D
 var _previous_mouse_mode : Input.MouseMode
-var _is_game_process_in_focus: bool
 var _restore_previous_mouse_mode : bool
 var _use_only_physics_for_picking = false
 
@@ -54,15 +53,6 @@ func set_active(on):
 
     _is_active = on
     _update_gizmo()
-
-
-func _notification(what: int):
-    match what:
-        NOTIFICATION_APPLICATION_FOCUS_IN:
-            _is_game_process_in_focus = true;
-        NOTIFICATION_APPLICATION_FOCUS_OUT:
-            _is_game_process_in_focus = false;
-
 
 func select_node(node):
     if node == _selected_node:

--- a/addons/runtime_debug_tools/scripts/debug_runtime_interaction_2d.gd
+++ b/addons/runtime_debug_tools/scripts/debug_runtime_interaction_2d.gd
@@ -9,6 +9,9 @@ signal on_object_picked(node)
 
 var _is_active = false
 var _previous_camera : Camera2D
+var _initialMouseMode : Input.MouseMode
+var _is_game_process_in_focus: bool
+var _set_initial_mouse_mode : bool
 var _use_only_physics_for_picking = false
 
 var _picker_ignore_nodes := {}
@@ -39,13 +42,27 @@ func set_active(on):
         
         _debug_camera.enabled = true
         _debug_camera.make_current()
+
+        _initialMouseMode = Input.get_mouse_mode()
     else:
         if _previous_camera:
             _debug_camera.enabled = false
             _previous_camera.make_current()
             _previous_camera = null
+
+        _set_initial_mouse_mode = true
+
     _is_active = on
     _update_gizmo()
+
+
+func _notification(what: int):
+    match what:
+        NOTIFICATION_APPLICATION_FOCUS_IN:
+            _is_game_process_in_focus = true;
+        NOTIFICATION_APPLICATION_FOCUS_OUT:
+            _is_game_process_in_focus = false;
+
 
 func select_node(node):
     if node == _selected_node:
@@ -66,6 +83,10 @@ func _ready():
     _ignore_nodes(get_parent())
     
 func _process(_delta: float) -> void:
+    if _is_game_process_in_focus and _set_initial_mouse_mode:
+        Input.mouse_mode = _initialMouseMode
+        _set_initial_mouse_mode = false;
+
     if not _is_active:
         return
         

--- a/addons/runtime_debug_tools/scripts/debug_runtime_interaction_3d.gd
+++ b/addons/runtime_debug_tools/scripts/debug_runtime_interaction_3d.gd
@@ -9,7 +9,6 @@ var _selected_node : Node
 var _is_active = false
 var _previous_camera : Camera3D
 var _previous_mouse_mode : Input.MouseMode
-var _is_game_process_in_focus : bool
 var _restore_previous_mouse_mode : bool
 var _use_only_physics_for_picking = false
 
@@ -42,15 +41,6 @@ func select_node(node):
         return
     _gizmo.visible = true
     _update_gizmo_pos()
-
-
-func _notification(what: int):
-    match what:
-        NOTIFICATION_APPLICATION_FOCUS_IN:
-            _is_game_process_in_focus = true;
-        NOTIFICATION_APPLICATION_FOCUS_OUT:
-            _is_game_process_in_focus = false;
-
 
 func set_active(on):
     var active_cam := get_viewport().get_camera_3d()

--- a/addons/runtime_debug_tools/scripts/debug_runtime_interaction_3d.gd
+++ b/addons/runtime_debug_tools/scripts/debug_runtime_interaction_3d.gd
@@ -8,9 +8,9 @@ signal on_object_picked(node)
 var _selected_node : Node
 var _is_active = false
 var _previous_camera : Camera3D
-var _initialMouseMode : Input.MouseMode
+var _previous_mouse_mode : Input.MouseMode
 var _is_game_process_in_focus : bool
-var _set_initial_mouse_mode : bool
+var _restore_previous_mouse_mode : bool
 var _use_only_physics_for_picking = false
 
 var _picker_ignore_nodes := {}
@@ -70,14 +70,14 @@ func set_active(on):
         
         _debug_camera.make_current()
 
-        _initialMouseMode = Input.get_mouse_mode()
+        _previous_mouse_mode = Input.get_mouse_mode()
     else:
         if _previous_camera:
             _previous_camera.make_current()
             _previous_camera = null
         remove_child(_debug_camera)
 
-        _set_initial_mouse_mode = true;
+        _restore_previous_mouse_mode = true;
 
     _is_active = on
     _update_gizmo_pos()
@@ -99,9 +99,10 @@ func _input(event):
         _pick_object()
 
 func _process(delta: float) -> void:
-    if _is_game_process_in_focus and _set_initial_mouse_mode:
-        Input.mouse_mode = _initialMouseMode
-        _set_initial_mouse_mode = false;
+
+    if get_window().has_focus() and _restore_previous_mouse_mode:
+        Input.mouse_mode = _previous_mouse_mode
+        _restore_previous_mouse_mode = false;
 
     if not _is_active:
         return

--- a/addons/runtime_debug_tools/scripts/debug_runtime_interaction_3d.gd
+++ b/addons/runtime_debug_tools/scripts/debug_runtime_interaction_3d.gd
@@ -8,6 +8,9 @@ signal on_object_picked(node)
 var _selected_node : Node
 var _is_active = false
 var _previous_camera : Camera3D
+var _initialMouseMode : Input.MouseMode
+var _is_game_process_in_focus : bool
+var _set_initial_mouse_mode : bool
 var _use_only_physics_for_picking = false
 
 var _picker_ignore_nodes := {}
@@ -40,6 +43,15 @@ func select_node(node):
     _gizmo.visible = true
     _update_gizmo_pos()
 
+
+func _notification(what: int):
+    match what:
+        NOTIFICATION_APPLICATION_FOCUS_IN:
+            _is_game_process_in_focus = true;
+        NOTIFICATION_APPLICATION_FOCUS_OUT:
+            _is_game_process_in_focus = false;
+
+
 func set_active(on):
     var active_cam := get_viewport().get_camera_3d()
 
@@ -58,12 +70,15 @@ func set_active(on):
         
         _debug_camera.make_current()
 
+        _initialMouseMode = Input.get_mouse_mode()
     else:
         if _previous_camera:
             _previous_camera.make_current()
             _previous_camera = null
         remove_child(_debug_camera)
-        
+
+        _set_initial_mouse_mode = true;
+
     _is_active = on
     _update_gizmo_pos()
 
@@ -84,6 +99,10 @@ func _input(event):
         _pick_object()
 
 func _process(delta: float) -> void:
+    if _is_game_process_in_focus and _set_initial_mouse_mode:
+        Input.mouse_mode = _initialMouseMode
+        _set_initial_mouse_mode = false;
+
     if not _is_active:
         return
 


### PR DESCRIPTION
Hey, the pull request  is related to this [issue](https://github.com/bbbscarter/GodotRuntimeDebugTools/issues/4).

_____

Description:
The enhancement is implemented via:

1. memorizing the initial mouse mode when entering the debug mode
2. setting the flag `_set_initial_mouse_mode` to `true` when we exiting from the Debugging mode.
3. tracking whether the game process is in focus or in background.
4. if `_set_initial_mouse_mode` is `true` and game process is in focus then we're setting initial mouse mode

Why we need to check out whether the game process is in focus or in background?
As for me, when running the game process in "windowed"  mode (Project settings -> Display -> Window -> Mode), switching back from RDT to character camera causes my mouse stuck in the frame dimensions of the game window, here's the showcase:


https://github.com/user-attachments/assets/2ffca708-353e-4f1d-8500-be93190f0fac

This happens, if the initial mouse mode of the game (before entering the debugging mode) has these values:

```
MOUSE_MODE_CAPTURED = 2
MOUSE_MODE_CONFINED = 3
MOUSE_MODE_CONFINED_HIDDEN 
```

To avoid this, I'm tracking whether the game process is actually in focus now.

