### PR TITLE
Fixed crash when clicking on objects in debug mode

### DIFF
--- a/addons/runtime_debug_tools/scripts/debug_runtime_interaction_3d.gd
+++ b/addons/runtime_debug_tools/scripts/debug_runtime_interaction_3d.gd
@@ -11,6 +11,7 @@ var _previous_camera : Camera3D
 var _previous_mouse_mode : Input.MouseMode
 var _restore_previous_mouse_mode : bool
 var _use_only_physics_for_picking = false
+var _click_queued := false
 
 var _picker_ignore_nodes := {}
 var _camera_pos_set := false
@@ -86,6 +87,11 @@ func _input(event):
     
     if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
         get_viewport().set_input_as_handled()
+        _click_queued = true
+
+func _physics_process(_delta: float) -> void:
+    if _click_queued:
+        _click_queued = false
         _pick_object()
 
 func _process(delta: float) -> void:


### PR DESCRIPTION
Fixes #7 

Caused by space state being locked during _input lifecycle. Mouse click now triggers a flag which will let the next _physics_process know to cast a ray.